### PR TITLE
Fix build error on Unity 2021

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -45,9 +45,5 @@
             </intent-filter>
         </service>
 
-        <meta-data
-            android:name="com.google.android.gms.version"
-            android:value="@integer/google_play_services_version" />
-
     </application>
 </manifest>

--- a/Assets/Plugins/Android/res.meta
+++ b/Assets/Plugins/Android/res.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3b322c1ae5b8e4f88bd57a4928c18b0b
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/Android/res/values.meta
+++ b/Assets/Plugins/Android/res/values.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 6587a8d013717464590870a43cc92ce4
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/Android/res/values/version.xml
+++ b/Assets/Plugins/Android/res/values/version.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <integer name="google_play_services_version">8298000</integer>
-</resources>

--- a/Assets/Plugins/Android/res/values/version.xml.meta
+++ b/Assets/Plugins/Android/res/values/version.xml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 928e7e049951649258db4334eadd905b
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
* Fix error when building native Android on Unity 2021
Providing Android resources in Assets/Plugins/Android/res was removed, please move your resources to an AAR or an Android Library.